### PR TITLE
Change AutoScaling Timeout to 15mins

### DIFF
--- a/templates/aws-refarch-wordpress-04-web.yaml
+++ b/templates/aws-refarch-wordpress-04-web.yaml
@@ -489,7 +489,7 @@ Resources:
     CreationPolicy:
       ResourceSignal:
         Count: !Ref WebAsgMin
-        Timeout: PT5M
+        Timeout: PT15M
   WebLaunchConfiguration74:
     Condition: PHP74
     Type: AWS::AutoScaling::LaunchConfiguration


### PR DESCRIPTION
Adding 15 mins timeout to AutoScaling Group, takes more than 5 minutes to validate the instances.